### PR TITLE
Allows this to handle caches containing strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ export default function expandCache(cache) {
 
   function createNode(data) {
     if (!data) return undefined;
+    if (typeof data !== 'object' && typeof data !== 'function') return data;
     if (data.$type) return expandChild(data);
     const node = {};
     const nodeCache = {};

--- a/test/index.js
+++ b/test/index.js
@@ -76,6 +76,22 @@ describe('falcor-expand-cache', () => {
     expect(expanded.very.deeply.nested.thing).toBe(expanded.very.deeply.nested.thing);
   });
 
+  it('can handle strings', () => {
+    const cache = {
+      article: {
+        title: 'Hello',
+        body: 'World',
+      },
+      articleRef: {
+        $type: 'ref',
+        value: ['article'],
+      },
+    };
+
+    const expanded = expand(cache);
+    expect(expanded.articleRef.title).toBe(expanded.article.title);
+  });
+
   it('can perform a big integration test', () => {
     const expanded = expand(require('./fixture.json'));
 


### PR DESCRIPTION
This is a one line change that lets the expandCache function handle caches containing strings. Previously if a string was passed to createNode, it would try iterate over the characters in the string, and expand them. However, a character is also a string, so it would do recursion forever on the first letter of the string and give Max Call Stack Size exceeded. 

The fix just checks that the node is actually a JS object. To validate that this is a bug, just remove the one line and run npm test and the stack should blow.
